### PR TITLE
feat: new banner animation performance optimization

### DIFF
--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -17,8 +17,6 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     if (!container) return
     try {
       const testRenderTime = renderTinyTestScene(container)
-      // eslint-disable-next-line no-console
-      console.log(testRenderTime)
       if (testRenderTime < 160) {
         const r = createBannerRender(container)
         setRender(r)

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -17,7 +17,7 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     if (!container) return
     try {
       const testRenderTime = renderTinyTestScene(container)
-      if (testRenderTime < 160) {
+      if (testRenderTime < 120) {
         const r = createBannerRender(container)
         setRender(r)
         return () => r.destroy()

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -4,7 +4,7 @@ import { BannerRender, createBannerRender } from './render'
 import styles from './index.module.scss'
 import { useIsMobile, usePrevious } from '../../../utils/hook'
 import BannerFallback from '../../../components/BannerFallback'
-import { renderTinyTestScene } from './tinyTestScene'
+import { tinyTestSceneRender } from './tinyTestScene'
 
 // eslint-disable-next-line no-underscore-dangle
 const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
@@ -16,7 +16,9 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     const container = ref.current
     if (!container) return
     try {
-      const testRenderTime = renderTinyTestScene(container)
+      // The `tinyTestSceneRender` is used to determine whether the performance of browser is sufficient to render the three.js animated banner
+      // Related issue: https://github.com/Magickbase/ckb-explorer-public-issues/issues/218
+      const testRenderTime = tinyTestSceneRender(container)
       if (testRenderTime < 120) {
         const r = createBannerRender(container)
         setRender(r)

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -4,7 +4,7 @@ import { BannerRender, createBannerRender } from './render'
 import styles from './index.module.scss'
 import { useIsMobile, usePrevious } from '../../../utils/hook'
 import BannerFallback from '../../../components/BannerFallback'
-import { createPioneerRender } from './pioneerRender'
+import { renderTinyTestScene } from './tinyTestScene'
 
 // eslint-disable-next-line no-underscore-dangle
 const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
@@ -16,9 +16,14 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     const container = ref.current
     if (!container) return
     try {
-      let r: BannerRender
-      createPioneerRender(container, setRender, () => createBannerRender(container))
-      return () => r && r.destroy()
+      const testRenderTime = renderTinyTestScene(container)
+      // eslint-disable-next-line no-console
+      console.log(testRenderTime)
+      if (testRenderTime < 160) {
+        const r = createBannerRender(container)
+        setRender(r)
+        return () => r.destroy()
+      }
     } catch (e) {
       if (e instanceof Error) {
         console.error(e.message)

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -19,7 +19,7 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
       // The `tinyTestSceneRender` is used to determine whether the performance of browser is sufficient to render the three.js animated banner
       // Related issue: https://github.com/Magickbase/ckb-explorer-public-issues/issues/218
       const testRenderTime = tinyTestSceneRender(container)
-      if (testRenderTime < 120) {
+      if (testRenderTime < 60) {
         const r = createBannerRender(container)
         setRender(r)
         return () => r.destroy()

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -4,6 +4,7 @@ import { BannerRender, createBannerRender } from './render'
 import styles from './index.module.scss'
 import { useIsMobile, usePrevious } from '../../../utils/hook'
 import BannerFallback from '../../../components/BannerFallback'
+import { createPioneerRender } from './pioneerRender'
 
 // eslint-disable-next-line no-underscore-dangle
 const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
@@ -15,9 +16,9 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     const container = ref.current
     if (!container) return
     try {
-      const r = createBannerRender(container)
-      setRender(r)
-      return () => r.destroy()
+      let r: BannerRender
+      createPioneerRender(container, setRender, () => createBannerRender(container))
+      return () => r && r.destroy()
     } catch (e) {
       if (e instanceof Error) {
         console.error(e.message)

--- a/src/pages/Home/Banner/pioneerRender.ts
+++ b/src/pages/Home/Banner/pioneerRender.ts
@@ -1,0 +1,98 @@
+import { DirectionalLight, OrthographicCamera, Scene, Vector3, WebGLRenderer, sRGBEncoding } from 'three'
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer'
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
+import { createSideFadeOutPass } from './shaderPass/sideFadeOutPass'
+import { createBloomComposerController } from './renderUtils'
+import { assert } from '../../../utils/error'
+import { BannerRender, createTextCubes } from './render'
+
+export function createPioneerRender(container: HTMLElement, setRender: (r?: BannerRender) => void, next: () => any) {
+  const width = container.clientWidth
+  const height = container.clientHeight
+  const aspect = width / height
+  const scene = new Scene()
+  // The following number constants are from the design draft.
+  const camera = new OrthographicCamera(-700 * aspect, 700 * aspect, 150 * aspect, -150 * aspect, -100000, 100000)
+  const renderer = new WebGLRenderer({ antialias: true, alpha: true })
+  renderer.setPixelRatio(window.devicePixelRatio)
+  renderer.outputEncoding = sRGBEncoding
+  renderer.setSize(width, height)
+  container.appendChild(renderer.domElement)
+
+  // Fixed a viewing angle.
+  camera.rotation.x = Math.PI / (180 / -37.46)
+  camera.rotation.y = Math.PI / (180 / -33.83)
+  camera.rotation.z = Math.PI / (180 / -28)
+  camera.position.x = -540
+  camera.position.z = 880
+  camera.position.y = 720
+  camera.updateWorldMatrix(true, false)
+
+  const cubeSize = new Vector3(100, 200, 100)
+  const gap = 10
+  const { mesh: textCubes } = createTextCubes(cubeSize, gap)
+  scene.add(textCubes)
+
+  const highlight1 = new DirectionalLight(0x999999, 12)
+  highlight1.position.set(1, 1, 0)
+  scene.add(highlight1)
+
+  const renderPass = new RenderPass(scene, camera)
+  const sideFadeOutPass = createSideFadeOutPass()
+  const bloomComposerCtl = createBloomComposerController(renderer, scene, width, height, [renderPass])
+
+  const finalComposer = new EffectComposer(renderer)
+  finalComposer.addPass(renderPass)
+  finalComposer.addPass(sideFadeOutPass)
+
+  let stopRenderLoop: (() => void) | null = null
+  let frame = 0
+  function render() {
+    frame++
+
+    const handle = requestAnimationFrame(render)
+    stopRenderLoop = () => cancelAnimationFrame(handle)
+
+    bloomComposerCtl.render()
+    finalComposer.render()
+  }
+  render()
+
+  function destroy() {
+    stopRenderLoop?.()
+
+    // It is expected that the rest of the resources will be automatically reclaimed by GC.
+    finalComposer.dispose()
+    renderer.dispose()
+
+    renderPass.dispose()
+    sideFadeOutPass.dispose()
+    bloomComposerCtl.dispose()
+
+    highlight1.dispose()
+
+    const meshes = [textCubes]
+    meshes.forEach(mesh => {
+      mesh.removeFromParent()
+      mesh.geometry.dispose()
+      assert(!Array.isArray(mesh.material))
+      mesh.material.dispose()
+    })
+
+    renderer.domElement.remove()
+  }
+
+  setTimeout(() => {
+    if (frame > 10) {
+      setRender(next())
+    } else {
+      setRender(undefined)
+    }
+    destroy()
+  }, 200)
+  setRender({
+    onNewBlock: () => {},
+    destroy,
+    onResize: () => {},
+  })
+}

--- a/src/pages/Home/Banner/render.ts
+++ b/src/pages/Home/Banner/render.ts
@@ -219,7 +219,11 @@ function createNormalCubes(
   return createInstancedCubeMesh(cubes, cubeIndexMap, boxGeometry, boxMaterial)
 }
 
-function createTextCubes(cubeSize: Vector3, spacingBetweenCubes: number, centerPos: Vector3 = new Vector3(0, 0, 0)) {
+export function createTextCubes(
+  cubeSize: Vector3,
+  spacingBetweenCubes: number,
+  centerPos: Vector3 = new Vector3(0, 0, 0),
+) {
   const cubeWidth = cubeSize.x
   const cubeHeight = cubeSize.y
   const cubeLong = cubeSize.z

--- a/src/pages/Home/Banner/tinyTestScene.ts
+++ b/src/pages/Home/Banner/tinyTestScene.ts
@@ -6,7 +6,7 @@ import { createBloomComposerController } from './renderUtils'
 import { assert } from '../../../utils/error'
 import { createTextCubes } from './render'
 
-export function renderTinyTestScene(container: HTMLElement) {
+export function tinyTestSceneRender(container: HTMLElement) {
   const scene = new Scene()
   // The following number constants are from the design draft.
   const camera = new OrthographicCamera()
@@ -43,8 +43,6 @@ export function renderTinyTestScene(container: HTMLElement) {
     bloomComposerCtl.render()
     finalComposer.render()
   }
-  const startRenderMark = performance.mark('start-render')
-  render()
 
   function destroy() {
     // It is expected that the rest of the resources will be automatically reclaimed by GC.
@@ -67,6 +65,8 @@ export function renderTinyTestScene(container: HTMLElement) {
 
     renderer.domElement.remove()
   }
+  const startRenderMark = performance.mark('start-render')
+  render()
   const endRenderMark = performance.mark('end-render')
   destroy()
   const { duration } = performance.measure('renderMeasure', startRenderMark.name, endRenderMark.name)

--- a/src/pages/Home/Banner/tinyTestScene.ts
+++ b/src/pages/Home/Banner/tinyTestScene.ts
@@ -4,30 +4,19 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
 import { createSideFadeOutPass } from './shaderPass/sideFadeOutPass'
 import { createBloomComposerController } from './renderUtils'
 import { assert } from '../../../utils/error'
-import { BannerRender, createTextCubes } from './render'
+import { createTextCubes } from './render'
 
-export function createPioneerRender(container: HTMLElement, setRender: (r?: BannerRender) => void, next: () => any) {
-  const width = container.clientWidth
-  const height = container.clientHeight
-  const aspect = width / height
+export function renderTinyTestScene(container: HTMLElement) {
+  const startTime = Date.now()
   const scene = new Scene()
   // The following number constants are from the design draft.
-  const camera = new OrthographicCamera(-700 * aspect, 700 * aspect, 150 * aspect, -150 * aspect, -100000, 100000)
+  const camera = new OrthographicCamera()
   const renderer = new WebGLRenderer({ antialias: true, alpha: true })
   renderer.setPixelRatio(window.devicePixelRatio)
   renderer.outputEncoding = sRGBEncoding
-  renderer.setSize(width, height)
   container.appendChild(renderer.domElement)
 
   // Fixed a viewing angle.
-  camera.rotation.x = Math.PI / (180 / -37.46)
-  camera.rotation.y = Math.PI / (180 / -33.83)
-  camera.rotation.z = Math.PI / (180 / -28)
-  camera.position.x = -540
-  camera.position.z = 880
-  camera.position.y = 720
-  camera.updateWorldMatrix(true, false)
-
   const cubeSize = new Vector3(100, 200, 100)
   const gap = 10
   const { mesh: textCubes } = createTextCubes(cubeSize, gap)
@@ -39,28 +28,25 @@ export function createPioneerRender(container: HTMLElement, setRender: (r?: Bann
 
   const renderPass = new RenderPass(scene, camera)
   const sideFadeOutPass = createSideFadeOutPass()
-  const bloomComposerCtl = createBloomComposerController(renderer, scene, width, height, [renderPass])
+  const bloomComposerCtl = createBloomComposerController(
+    renderer,
+    scene,
+    container.clientWidth,
+    container.clientHeight,
+    [renderPass],
+  )
 
   const finalComposer = new EffectComposer(renderer)
   finalComposer.addPass(renderPass)
   finalComposer.addPass(sideFadeOutPass)
 
-  let stopRenderLoop: (() => void) | null = null
-  let frame = 0
   function render() {
-    frame++
-
-    const handle = requestAnimationFrame(render)
-    stopRenderLoop = () => cancelAnimationFrame(handle)
-
     bloomComposerCtl.render()
     finalComposer.render()
   }
   render()
 
   function destroy() {
-    stopRenderLoop?.()
-
     // It is expected that the rest of the resources will be automatically reclaimed by GC.
     finalComposer.dispose()
     renderer.dispose()
@@ -81,18 +67,6 @@ export function createPioneerRender(container: HTMLElement, setRender: (r?: Bann
 
     renderer.domElement.remove()
   }
-
-  setTimeout(() => {
-    if (frame > 10) {
-      setRender(next())
-    } else {
-      setRender(undefined)
-    }
-    destroy()
-  }, 200)
-  setRender({
-    onNewBlock: () => {},
-    destroy,
-    onResize: () => {},
-  })
+  destroy()
+  return Date.now() - startTime
 }

--- a/src/pages/Home/Banner/tinyTestScene.ts
+++ b/src/pages/Home/Banner/tinyTestScene.ts
@@ -7,7 +7,6 @@ import { assert } from '../../../utils/error'
 import { createTextCubes } from './render'
 
 export function renderTinyTestScene(container: HTMLElement) {
-  const startTime = Date.now()
   const scene = new Scene()
   // The following number constants are from the design draft.
   const camera = new OrthographicCamera()
@@ -44,6 +43,7 @@ export function renderTinyTestScene(container: HTMLElement) {
     bloomComposerCtl.render()
     finalComposer.render()
   }
+  const startRenderMark = performance.mark('start-render')
   render()
 
   function destroy() {
@@ -67,6 +67,8 @@ export function renderTinyTestScene(container: HTMLElement) {
 
     renderer.domElement.remove()
   }
+  const endRenderMark = performance.mark('end-render')
   destroy()
-  return Date.now() - startTime
+  const { duration } = performance.measure('renderMeasure', startRenderMark.name, endRenderMark.name)
+  return duration
 }


### PR DESCRIPTION
> display different banner between old and new, render new banner according to render time of tiny scene

> The first video shows that the old banner is displayed due to long time of test tiny render

https://user-images.githubusercontent.com/7877698/231226805-b2f7d940-837e-49ef-bd89-5988b810db79.mov

---
> This video shows that the new banner displayed after performance pass in test tiny render

https://user-images.githubusercontent.com/7877698/231226886-72df372b-d412-4d85-be7d-ba3ea86dc5f0.mov

