### PR TITLE
fix: Remove cell.cellInfo.lock

### DIFF
--- a/src/pages/Transaction/TransactionCellScript/index.tsx
+++ b/src/pages/Transaction/TransactionCellScript/index.tsx
@@ -69,7 +69,7 @@ const handleFetchCellInfo = async (
       const wrapper: Response.Wrapper<State.Script> | null = await fetchScript('lock_scripts', `${cell.id}`)
       return wrapper ? wrapper.attributes : initScriptContent.lock
     }
-    return cell.cellInfo.lock || initScriptContent.lock
+    return initScriptContent.lock
   }
 
   const fetchType = async () => {


### PR DESCRIPTION
### issues:https://github.com/Magickbase/ckb-explorer-public-issues/issues/341
Remove  cell.cellInfo.lock, as the backend no longer returns cellInfo.lock.

![image](https://github.com/Magickbase/ckb-explorer-frontend/assets/18475950/dbd2ddd0-88a7-4240-9d72-86c8ee8e5211)
