### PR TITLE
feat: remove the unreasonable default args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:18.13.0-alpine as builder
 
 ARG SENTRY_AUTH_TOKEN
-ARG SENTRY_DSN=https://3357d5dab93b4a88bea7f0ea4a6439f2@o1200558.ingest.sentry.io/4504750561034240
+ARG SENTRY_DSN
 ARG API_URL=https://testnet-api.explorer.nervos.org
 ARG CHAIN_TYPE=testnet
-ARG GA_ID=G-F4MS15DMS6
+ARG GA_ID
 ARG MAINNET_URL=https://explorer.nervos.org
 ARG TESTNET_NAME=pudge
 


### PR DESCRIPTION
Avoid automatic reporting of data to our servers on individual deployments.