### PR TITLE
refactor: use backend page size for pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage/
 !/.env.*.example
 .secrets
 !.secrets.example
+.eslintcache

--- a/src/pages/BlockDetail/index.tsx
+++ b/src/pages/BlockDetail/index.tsx
@@ -13,7 +13,7 @@ import { defaultBlockInfo } from './state'
 
 export default () => {
   const { param: blockHeightOrHash } = useParams<{ param: string }>()
-  const { currentPage, pageSize, setPage } = usePaginationParamsInPage()
+  const { currentPage, pageSize: _pageSize, setPage } = usePaginationParamsInPage()
 
   const queryBlock = useQuery(['block', blockHeightOrHash], async () => {
     const wrapper = await fetchBlock(blockHeightOrHash)
@@ -24,19 +24,22 @@ export default () => {
   const block = queryBlock.data ?? defaultBlockInfo
 
   const queryBlockTransactions = useQuery(
-    ['block-transactions', blockHash, currentPage, pageSize],
+    ['block-transactions', blockHash, currentPage, _pageSize],
     async () => {
       assert(blockHash != null)
-      const { data, meta } = await fetchTransactionsByBlockHash(blockHash, currentPage, pageSize)
+      const { data, meta } = await fetchTransactionsByBlockHash(blockHash, currentPage, _pageSize)
       return {
         transactions: data.map(wrapper => wrapper.attributes),
         total: meta?.total ?? 0,
+        pageSize: meta?.pageSize,
       }
     },
     {
       enabled: blockHash != null,
     },
   )
+
+  const pageSize = queryBlockTransactions.data?.pageSize ?? _pageSize
 
   return (
     <Content>

--- a/src/pages/NervosDao/index.tsx
+++ b/src/pages/NervosDao/index.tsx
@@ -25,7 +25,7 @@ export const NervosDao = () => {
   const { push } = useHistory()
   const [t] = useTranslation()
 
-  const { currentPage, pageSize, setPage } = usePaginationParamsInPage()
+  const { currentPage, pageSize: _pageSize, setPage } = usePaginationParamsInPage()
   const params = useSearchParams('tab')
   const tab = params.tab as 'transactions' | 'depositors'
   const daoTab = tab || 'transactions'
@@ -41,7 +41,7 @@ export const NervosDao = () => {
   const isInvalidFilter = filtering && containSpecialChar(filterText)
 
   const queryNervosDaoTransactions = useQuery(
-    ['nervos-dao-transactions', currentPage, pageSize, filterText, isInvalidFilter],
+    ['nervos-dao-transactions', currentPage, _pageSize, filterText, isInvalidFilter],
     async () => {
       if (filterText != null) {
         if (isInvalidFilter) {
@@ -50,7 +50,7 @@ export const NervosDao = () => {
 
         // search address
         if (filterText.startsWith('ckt') || filterText.startsWith('ckb')) {
-          const { data, meta } = await fetchNervosDaoTransactionsByAddress(filterText, currentPage, pageSize)
+          const { data, meta } = await fetchNervosDaoTransactionsByAddress(filterText, currentPage, _pageSize)
           const transactions = data.map(wrapper => wrapper.attributes)
           return {
             transactions,
@@ -67,11 +67,12 @@ export const NervosDao = () => {
         }
       }
 
-      const { data, meta } = await fetchNervosDaoTransactions(currentPage, pageSize)
+      const { data, meta } = await fetchNervosDaoTransactions(currentPage, _pageSize)
       const transactions = data.map(wrapper => wrapper.attributes)
       return {
         transactions,
         total: meta?.total ?? transactions.length,
+        pageSize: meta?.pageSize,
       }
     },
   )
@@ -81,6 +82,8 @@ export const NervosDao = () => {
     const { data } = await fetchNervosDaoDepositors()
     return { depositors: data.map(wrapper => wrapper.attributes) }
   })
+
+  const pageSize = queryNervosDaoTransactions.data?.pageSize ?? _pageSize
 
   return (
     <Content>

--- a/src/pages/SimpleUDT/index.tsx
+++ b/src/pages/SimpleUDT/index.tsx
@@ -44,7 +44,7 @@ export const SimpleUDT = () => {
   const [t] = useTranslation()
   const [showType, setShowType] = useState(false)
   const { hash: typeHash } = useParams<{ hash: string }>()
-  const { currentPage, pageSize, setPage, setPageSize } = usePaginationParamsInPage()
+  const { currentPage, pageSize: _pageSize, setPage, setPageSize } = usePaginationParamsInPage()
 
   useEffect(() => {
     getTipBlockNumber(dispatch)
@@ -63,7 +63,7 @@ export const SimpleUDT = () => {
   const isInvalidFilter = filtering && containSpecialChar(filterText)
 
   const querySimpleUDTTransactions = useQuery(
-    ['simple-udt-transactions', typeHash, currentPage, pageSize, filterText, isInvalidFilter],
+    ['simple-udt-transactions', typeHash, currentPage, _pageSize, filterText, isInvalidFilter],
     async () => {
       if (filterText != null) {
         if (isInvalidFilter) {
@@ -74,6 +74,7 @@ export const SimpleUDT = () => {
         return {
           transactions: data.map(wrapper => wrapper.attributes),
           total: meta?.total ?? 0,
+          pageSize: meta?.pageSize,
         }
       }
 
@@ -97,6 +98,7 @@ export const SimpleUDT = () => {
   )
   const total = querySimpleUDTTransactions.data?.total ?? 0
   const filterNoResult = filtering && (isInvalidFilter || querySimpleUDTTransactions.isError)
+  const pageSize: number = querySimpleUDTTransactions.data?.pageSize ?? _pageSize
 
   return (
     <Content>

--- a/src/pages/Tokens/index.tsx
+++ b/src/pages/Tokens/index.tsx
@@ -94,19 +94,21 @@ const TokenItem = ({ token, isLast }: { token: State.UDT; isLast?: boolean }) =>
 
 export default () => {
   const isMobile = useIsMobile()
-  const { currentPage, pageSize, setPage } = usePaginationParamsInPage()
+  const { currentPage, pageSize: _pageSize, setPage } = usePaginationParamsInPage()
 
-  const query = useQuery(['tokens', currentPage, pageSize], async () => {
-    const { data, meta } = await fetchTokens(currentPage, pageSize)
+  const query = useQuery(['tokens', currentPage, _pageSize], async () => {
+    const { data, meta } = await fetchTokens(currentPage, _pageSize)
     if (data == null || data.length === 0) {
       throw new Error('Tokens empty')
     }
     return {
       total: meta?.total ?? 0,
       tokens: data.map(wrapper => wrapper.attributes),
+      pageSize: meta?.pageSize,
     }
   })
   const total = query.data?.total ?? 0
+  const pageSize = query.data?.pageSize ?? _pageSize
   const totalPages = Math.ceil(total / pageSize)
 
   return (

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -258,6 +258,7 @@ export function usePaginationParamsFromSearch(opts: {
   }
 }
 
+// TODO: refactor this hook
 export const usePaginationParamsInPage = () =>
   usePaginationParamsFromSearch({
     defaultPage: PageParams.PageNo,


### PR DESCRIPTION
![image](https://github.com/nervosnetwork/ckb-explorer-frontend/assets/20639676/f07101a5-2851-4b35-9b7e-8f5e7a9bb925)

This PR use the backend's page size for pagination in UI.

For more details, please see: https://github.com/Magickbase/ckb-explorer-public-issues/issues/356