### PR TITLE
ci: add an action to merge forked/develop to origin/develop

### DIFF
--- a/.github/workflows/pr-from-forked-to-origin.yml
+++ b/.github/workflows/pr-from-forked-to-origin.yml
@@ -1,0 +1,32 @@
+name: Open PR from forked/develop to origin/develop
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  default:
+    name: Open PR from forked/develop to origin/develop
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for opening PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Open PR to origin repo
+        # IS_SYNCED_TO_ORIGIN_REPO is set in repo/settings/variables/actions
+        if: var.IS_SYNCED_TO_ORIGIN_REPO == 'true'
+        uses: actions/script@v6
+        with:
+          script: |
+            github.rest.pulls.create({
+              owner: `nervosnetwork`,
+              repo: context.repo.repo,
+              head: context.ref,
+              title: `Merge ${context.ref} to develop`,
+              body: `Ready to deploy`,
+            })
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub action to open a PR from forked/develop to origin/develop by setting `IS_SYNCED_TO_ORIGIN_REPO = true` at `/settings/variables/actions`

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/414