### PR TITLE
feat: update threshold of halving countdown

### DIFF
--- a/src/components/Banner/HalvingBanner.tsx
+++ b/src/components/Banner/HalvingBanner.tsx
@@ -34,7 +34,7 @@ function numberToOrdinal(number: number) {
 
 export const HalvingBanner = () => {
   const { estimatedDate, halvingCount, inCelebration, isLoading } = useHalving()
-  const [days, hours, minutes, seconds, expired] = useCountdown(estimatedDate)
+  const [days, hours, minutes, seconds, isComingSoon] = useCountdown(estimatedDate)
   const isMobile = useIsMobile()
   const [t, { language }] = useTranslation()
 
@@ -60,7 +60,7 @@ export const HalvingBanner = () => {
       return t('halving.learn_more')
     }
 
-    if (expired) {
+    if (isComingSoon) {
       return t('halving.comming_soon')
     }
 

--- a/src/pages/Halving/index.tsx
+++ b/src/pages/Halving/index.tsx
@@ -54,7 +54,7 @@ export const HalvingCountdownPage = () => {
     (((currentEpoch % EPOCHS_PER_HALVING) * THEORETICAL_EPOCH_TIME - currentEpochUsedTime) /
       (EPOCHS_PER_HALVING * THEORETICAL_EPOCH_TIME)) *
     100
-  const [days, hours, minutes, seconds, expired] = useCountdown(estimatedDate)
+  const [days, hours, minutes, seconds, isComingSoon] = useCountdown(estimatedDate)
 
   const shortCountdown = () => {
     if (days > 0) {
@@ -132,7 +132,7 @@ export const HalvingCountdownPage = () => {
       )
     }
 
-    if (expired) {
+    if (isComingSoon) {
       return (
         <div className={styles.halvingPanelWrapper}>
           <div className={classnames(styles.halvingPanel, styles.loadingPanel)}>

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -604,7 +604,9 @@ export const useCountdown = (targetDate: Date): [number, number, number, number,
   const minutes = expired ? 0 : Math.floor((countdown % (1000 * 60 * 60)) / (1000 * 60))
   const seconds = expired ? 0 : Math.floor((countdown % (1000 * 60)) / 1000)
 
-  return [days, hours, minutes, seconds, expired]
+  const isComingSoon = countdown <= 3_000 // show coming soon when countdown is less than 3s
+
+  return [days, hours, minutes, seconds, isComingSoon]
 }
 
 export const useSingleHalving = (_halvingCount = 1) => {


### PR DESCRIPTION
Before this PR, the countdown shows "Coming soon" after `Halving Countdown 0 Seconds", it's a bit confusing because "Halvd" is expected when the countdown lefts 0s.

This PR moves the threshold of "Coming soon" to 3s as a buffer.

https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/5a5670e2-0383-402f-a041-ddcf58623696
