### PR TITLE
fix: halving activated block_number

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,7 @@
     "halving": {
       "congratulations": "Congratulations",
       "the": "the",
-      "actived": "is atived on block",
+      "actived": "is activated on block",
       "halving": "halving",
       "next": "next",
       "and": "and",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,7 @@
     "halving": {
       "congratulations": "Congratulations",
       "the": "the",
-      "actived": "is activated on block",
+      "actived": "is atived on block",
       "halving": "halving",
       "next": "next",
       "and": "and",

--- a/src/pages/Halving/index.tsx
+++ b/src/pages/Halving/index.tsx
@@ -75,9 +75,6 @@ export const HalvingCountdownPage = () => {
   })
   const shareUrl = `https://x.com/share?text=${encodeURIComponent(shareText)}&hashtags=CKB%2CPoW%2CHalving`
   const getTargetBlockByHavingCount = (count: number) => {
-    // eslint-disable-next-line no-console
-    console.log(epochBlockMap, EPOCHS_PER_HALVING * count, epochBlockMap.get(EPOCHS_PER_HALVING * count))
-
     return epochBlockMap.get(EPOCHS_PER_HALVING * count)
   }
 

--- a/src/pages/Halving/index.tsx
+++ b/src/pages/Halving/index.tsx
@@ -15,7 +15,7 @@ import { HalvingTable } from './HalvingTable'
 import { HalvingInfo } from './HalvingInfo'
 import SmallLoading from '../../components/Loading/SmallLoading'
 import { HalvingCountdown } from './HalvingCountdown'
-import { useCountdown, useHalving, useIsMobile, useEpochStartBlock } from '../../utils/hook'
+import { useCountdown, useHalving, useIsMobile, useEpochBlockMap } from '../../utils/hook'
 import { getPrimaryColor, EPOCHS_PER_HALVING, THEORETICAL_EPOCH_TIME } from '../../constants/common'
 import styles from './index.module.scss'
 import { useCurrentLanguage } from '../../utils/i18n'
@@ -47,7 +47,7 @@ export const HalvingCountdownPage = () => {
   const isMobile = useIsMobile()
   const { currentEpoch, estimatedDate, currentEpochUsedTime, halvingCount, inCelebration, skipCelebration, isLoading } =
     useHalving()
-  const { epochStartMap, isLoading: epochStartLoading } = useEpochStartBlock()
+  const { epochBlockMap } = useEpochBlockMap()
 
   const percent =
     (((currentEpoch % EPOCHS_PER_HALVING) * THEORETICAL_EPOCH_TIME - currentEpochUsedTime) /
@@ -75,15 +75,14 @@ export const HalvingCountdownPage = () => {
   })
   const shareUrl = `https://x.com/share?text=${encodeURIComponent(shareText)}&hashtags=CKB%2CPoW%2CHalving`
   const getTargetBlockByHavingCount = (count: number) => {
-    if (epochStartMap[EPOCHS_PER_HALVING * count]) {
-      return epochStartMap[EPOCHS_PER_HALVING * count]
-    }
+    // eslint-disable-next-line no-console
+    console.log(epochBlockMap, EPOCHS_PER_HALVING * count, epochBlockMap.get(EPOCHS_PER_HALVING * count))
 
-    return undefined
+    return epochBlockMap.get(EPOCHS_PER_HALVING * count)
   }
 
   const renderHalvingPanel = () => {
-    if (isLoading || epochStartLoading || Number.isNaN(seconds)) {
+    if (isLoading || Number.isNaN(seconds)) {
       return (
         <div className={styles.halvingPanelWrapper}>
           <div className={classnames(styles.halvingPanel, styles.loadingPanel)}>

--- a/src/pages/Halving/index.tsx
+++ b/src/pages/Halving/index.tsx
@@ -14,9 +14,8 @@ import { ReactComponent as WarningCircle } from '../../assets/warning_circle.svg
 import { HalvingTable } from './HalvingTable'
 import { HalvingInfo } from './HalvingInfo'
 import SmallLoading from '../../components/Loading/SmallLoading'
-import { useStatistics } from '../../services/ExplorerService'
 import { HalvingCountdown } from './HalvingCountdown'
-import { useCountdown, useHalving, useIsMobile } from '../../utils/hook'
+import { useCountdown, useHalving, useIsMobile, useEpochStartBlock } from '../../utils/hook'
 import { getPrimaryColor, EPOCHS_PER_HALVING, THEORETICAL_EPOCH_TIME } from '../../constants/common'
 import styles from './index.module.scss'
 import { useCurrentLanguage } from '../../utils/i18n'
@@ -46,9 +45,9 @@ function numberToOrdinal(number: number) {
 export const HalvingCountdownPage = () => {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
-  const statistics = useStatistics()
   const { currentEpoch, estimatedDate, currentEpochUsedTime, halvingCount, inCelebration, skipCelebration, isLoading } =
     useHalving()
+  const { epochStartMap, isLoading: epochStartLoading } = useEpochStartBlock()
 
   const percent =
     (((currentEpoch % EPOCHS_PER_HALVING) * THEORETICAL_EPOCH_TIME - currentEpochUsedTime) /
@@ -76,15 +75,15 @@ export const HalvingCountdownPage = () => {
   })
   const shareUrl = `https://x.com/share?text=${encodeURIComponent(shareText)}&hashtags=CKB%2CPoW%2CHalving`
   const getTargetBlockByHavingCount = (count: number) => {
-    return (
-      EPOCHS_PER_HALVING *
-      (statistics.epochInfo.epochLength ? parseInt(statistics.epochInfo.epochLength, 10) : 1800) *
-      count
-    )
+    if (epochStartMap[EPOCHS_PER_HALVING * count]) {
+      return epochStartMap[EPOCHS_PER_HALVING * count]
+    }
+
+    return undefined
   }
 
   const renderHalvingPanel = () => {
-    if (isLoading || Number.isNaN(seconds)) {
+    if (isLoading || epochStartLoading || Number.isNaN(seconds)) {
       return (
         <div className={styles.halvingPanelWrapper}>
           <div className={classnames(styles.halvingPanel, styles.loadingPanel)}>
@@ -111,9 +110,13 @@ export const HalvingCountdownPage = () => {
                 {t('halving.halving')}
                 {t('symbol.char_space')}
                 {t('halving.actived')}{' '}
-                <a className={styles.textPrimary} href={`/block/${getTargetBlockByHavingCount(halvingCount)}`}>
-                  {new BigNumber(getTargetBlockByHavingCount(halvingCount)).toFormat()}.
-                </a>
+                {getTargetBlockByHavingCount(halvingCount) ? (
+                  <a className={styles.textPrimary} href={`/block/${getTargetBlockByHavingCount(halvingCount)}`}>
+                    {new BigNumber(getTargetBlockByHavingCount(halvingCount)!).toFormat()}.
+                  </a>
+                ) : (
+                  <SmallLoading />
+                )}
               </div>
             </div>
             <div className={styles.textCenter}>


### PR DESCRIPTION
The previous calculation of the blocks where halving occurs used the theoretical value of 1800, which was changed to the actual number of blocks

reslove: https://github.com/Magickbase/ckb-explorer-public-issues/issues/487