### PR TITLE
fix: fix auto-scale of y-axis in uncle rate chart

### DIFF
--- a/src/pages/StatisticsChart/mining/UncleRate.tsx
+++ b/src/pages/StatisticsChart/mining/UncleRate.tsx
@@ -6,11 +6,6 @@ import { ChartItem, explorerService } from '../../../services/ExplorerService'
 import { useCurrentLanguage } from '../../../utils/i18n'
 import { ChartColorConfig } from '../../../constants/common'
 
-const max = (statisticUncleRates: ChartItem.UncleRate[]) => {
-  const array = statisticUncleRates.flatMap(data => Number(data.uncleRate) * 100)
-  return Math.max(5, Math.ceil(Math.max(...array)))
-}
-
 const useOption = (
   statisticUncleRates: ChartItem.UncleRate[],
   chartColor: ChartColorConfig,
@@ -68,8 +63,6 @@ const useOption = (
         name: isMobile || isThumbnail ? '' : t('block.uncle_rate'),
         type: 'value',
         scale: true,
-        max: max(statisticUncleRates),
-        min: 0,
         axisLine: {
           lineStyle: {
             color: chartColor.colors[0],


### PR DESCRIPTION
Before:
<img width="1286" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/61cd9f65-defd-4900-8948-5aae9d3d73b5">


After:
![image](https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/c108c62b-2f24-47e8-bb3d-79867a3c5527)

Preview: https://ckb-explorer-frontend-in-magickbase-repo-git-ce7281-magickbase.vercel.app/charts/uncle-rate