### PR TITLE
feat: optimize the initial states of charts

### DIFF
--- a/src/pages/StatisticsChart/activities/CellCount.tsx
+++ b/src/pages/StatisticsChart/activities/CellCount.tsx
@@ -99,6 +99,11 @@ const useOption = (
               name: t('statistic.dead_cell'),
             },
           ],
+      selected: {
+        [t('statistic.all_cells')]: false,
+        [t('statistic.live_cell')]: true,
+        [t('statistic.dead_cell')]: false,
+      },
     },
     grid: isThumbnail ? gridThumbnail : grid,
     dataZoom: isThumbnail ? [] : DATA_ZOOM_CONFIG,

--- a/src/pages/StatisticsChart/block/AverageBlockTime.tsx
+++ b/src/pages/StatisticsChart/block/AverageBlockTime.tsx
@@ -80,7 +80,7 @@ const useOption = (
       : undefined,
     grid: isThumbnail ? gridThumbnail : grid,
     /* Selection starts from 1% because the average block time is extremely high on launch */
-    dataZoom: isThumbnail ? [] : DATA_ZOOM_CONFIG.map(zoom => ({ ...zoom, start: 1 })),
+    dataZoom: DATA_ZOOM_CONFIG.map(zoom => ({ ...zoom, show: !isThumbnail, start: 1 })),
     xAxis: [
       {
         name: isMobile || isThumbnail ? '' : t('statistic.date'),

--- a/src/pages/StatisticsChart/mining/UncleRate.tsx
+++ b/src/pages/StatisticsChart/mining/UncleRate.tsx
@@ -52,7 +52,8 @@ const useOption = (
         }
       : undefined,
     grid: isThumbnail ? gridThumbnail : grid,
-    dataZoom: isThumbnail ? [] : DATA_ZOOM_CONFIG,
+    /* Selection starts from 1% because the uncle rate starts from 0 on launch */
+    dataZoom: DATA_ZOOM_CONFIG.map(zoom => ({ ...zoom, show: !isThumbnail, start: 1 })),
     xAxis: [
       {
         name: isMobile || isThumbnail ? '' : t('statistic.date'),


### PR DESCRIPTION
1. only show live cell count by default;
2. unify selection of avg-block-time of its thumnail and large chart;
3. offset 1% start point of uncle rate because its initial value makes the chart obsure, similar to an outlier at the start point.

---

Before:
<img width="295" alt="image" src="https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/aaeb454f-9f70-432e-ae76-7def287822d6">
<img width="290" alt="image" src="https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/40fd51f7-fb52-4b1d-b7af-293d61d5ce5b">
<img width="294" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/4251e740-077e-4a2b-a252-de9291473b7f">

After:
<img width="294" alt="image" src="https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/a700f9fd-26b0-48bf-a558-123dff7077b9">
<img width="291" alt="image" src="https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/6efef0da-faf3-4f62-9391-808293043463">
<img width="294" alt="image" src="https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/61dad9cc-805e-4a59-ad5c-db37faac07bb">

Change in uncle rate chart is not obvious until https://github.com/Magickbase/ckb-explorer-frontend/pull/172 is merged