### PR TITLE
fix: fix layout of uncle rate chart

### DIFF
--- a/src/pages/StatisticsChart/mining/UncleRate.tsx
+++ b/src/pages/StatisticsChart/mining/UncleRate.tsx
@@ -25,7 +25,7 @@ const useOption = (
   }
   const grid = {
     left: '3%',
-    right: '3%',
+    right: isMobile ? '12%' : '5%',
     top: '5%',
     bottom: '5%',
     containLabel: true,


### PR DESCRIPTION
Set the right offset larger when it's on mobile

Before:

https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/fb18b802-7d68-4727-8067-32c188dd5e8f

After:


https://github.com/nervosnetwork/ckb-explorer-frontend/assets/7271329/de07d945-ac4b-42e5-aca4-f3547a1c8c20

Ref: https://github.com/Magickbase/ckb-explorer-frontend/pull/173#issuecomment-1851235662