### PR TITLE
fix: fix color of parentheses in transaction lite list

### DIFF
--- a/src/pages/Transaction/TransactionComp/TransactionLite/TransactionLite.module.scss
+++ b/src/pages/Transaction/TransactionComp/TransactionLite/TransactionLite.module.scss
@@ -159,3 +159,21 @@
     }
   }
 }
+
+.ckbDiff {
+  &::before {
+    content: '(';
+  }
+
+  &::after {
+    content: ')';
+  }
+
+  &[data-diff-status='positive'] {
+    color: var(--primary-color);
+  }
+
+  &[data-diff-status='negative'] {
+    color: var(--accent-color);
+  }
+}

--- a/src/pages/Transaction/TransactionComp/TransactionLite/TransactionLite.tsx
+++ b/src/pages/Transaction/TransactionComp/TransactionLite/TransactionLite.tsx
@@ -123,13 +123,25 @@ const TransferAmount: FC<{ transfer: TransactionRecordTransfer }> = ({ transfer 
 
   const capacityChange = shannonToCkb(transfer.capacity)
 
+  const ckbDiff = new BigNumber(capacityChange)
+  let ckbDiffStatus = ''
+  if (ckbDiff.isNegative()) {
+    ckbDiffStatus = 'negative'
+  } else if (!ckbDiff.isZero()) {
+    ckbDiffStatus = 'positive'
+  } else {
+    // skip
+  }
+
   if (isNft) {
     // FIXME: direction should be returned from API
     // Tracked by issue https://github.com/Magickbase/ckb-explorer-public-issues/issues/503
     return (
       <div>
         ID: {transfer.mNftInfo?.tokenId ?? 'Unknown'}
-        (<Capacity capacity={capacityChange} type="diff" display="short" />)
+        <div className={styles.ckbDiff} data-diff-status={ckbDiffStatus}>
+          <Capacity capacity={capacityChange} type="diff" display="short" />
+        </div>
       </div>
     )
   }
@@ -142,7 +154,9 @@ const TransferAmount: FC<{ transfer: TransactionRecordTransfer }> = ({ transfer 
       return (
         <>
           <Capacity capacity={amountChange} type="diff" unit={null} display="short" />
-          (<Capacity capacity={capacityChange} type="diff" display="short" />)
+          <div className={styles.ckbDiff} data-diff-status={ckbDiffStatus}>
+            <Capacity capacity={capacityChange} type="diff" display="short" />
+          </div>
         </>
       )
     }
@@ -157,7 +171,10 @@ const TransferAmount: FC<{ transfer: TransactionRecordTransfer }> = ({ transfer 
     return (
       <>
         <div className={styles.udtAmount} data-diff-status={diffStatus}>{`${t('udt.unknown_amount')}`}</div>
-        (<Capacity capacity={capacityChange} type="diff" display="short" />)
+
+        <div className={styles.ckbDiff} data-diff-status={ckbDiffStatus}>
+          <Capacity capacity={capacityChange} type="diff" display="short" />
+        </div>
       </>
     )
   }


### PR DESCRIPTION
According to https://github.com/Magickbase/ckb-explorer-public-issues/issues/503#issuecomment-1870144497, the color of `()` should be the same as `B`

Before:
<img width="1295" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/240cdcc4-2331-4a39-9fc5-19f771fe28e4">
After:
<img width="1304" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/a22b9e0c-4dd8-4dcb-8c86-71ca06ac20bb">
