### PR TITLE
feat: display spore id in hex string format

### DIFF
--- a/src/pages/NftCollectionInfo/NftCollectionInventory/index.tsx
+++ b/src/pages/NftCollectionInfo/NftCollectionInventory/index.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as Cover } from '../../../assets/nft_cover.svg'
 import styles from './styles.module.scss'
 import { getPrimaryColor } from '../../../constants/common'
 import { explorerService } from '../../../services/ExplorerService'
-import { handleNftImgError, patchMibaoImg } from '../../../utils/util'
+import { formatNftDisplayId, handleNftImgError, patchMibaoImg } from '../../../utils/util'
 import type { NFTItem } from '../../../services/ExplorerService/fetcher'
 
 const primaryColor = getPrimaryColor()
@@ -90,7 +90,7 @@ const NftCollectionInventory: React.FC<{
                   color: primaryColor,
                 }}
               >
-                {item.token_id}
+                {formatNftDisplayId(item.token_id, item.standard)}
               </Link>
             </div>
             <div className={styles.owner}>

--- a/src/pages/NftCollectionInfo/NftCollectionTransfers/index.tsx
+++ b/src/pages/NftCollectionInfo/NftCollectionTransfers/index.tsx
@@ -10,7 +10,7 @@ import { parseSporeCellData } from '../../../utils/spore'
 import type { TransferListRes, TransferRes } from '../../../services/ExplorerService/fetcher'
 import styles from './styles.module.scss'
 import { getPrimaryColor } from '../../../constants/common'
-import { handleNftImgError, patchMibaoImg } from '../../../utils/util'
+import { formatNftDisplayId, handleNftImgError, patchMibaoImg } from '../../../utils/util'
 import { explorerService } from '../../../services/ExplorerService'
 import { dayjs } from '../../../utils/date'
 import { useParsedDate, useTimestamp } from '../../../hooks'
@@ -154,7 +154,7 @@ const TransferTableRow: FC<{
             }}
             className={styles.tokenId}
           >
-            {`id: ${item.item.token_id}`}
+            {`id: ${formatNftDisplayId(item.item.token_id, item.item.standard)}`}
           </Link>
         </div>
       </td>
@@ -284,7 +284,7 @@ const TransferCard: FC<{
             textOverflow: 'ellipsis',
           }}
         >
-          {`id: ${item.item.token_id}`}
+          {`id: ${formatNftDisplayId(item.item.token_id, item.item.standard)}`}
         </Link>
       </div>
       <dl>

--- a/src/pages/NftInfo/index.tsx
+++ b/src/pages/NftInfo/index.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as Cover } from '../../assets/nft_cover.svg'
 import { explorerService } from '../../services/ExplorerService'
 import { getPrimaryColor } from '../../constants/common'
 import styles from './styles.module.scss'
-import { patchMibaoImg, handleNftImgError } from '../../utils/util'
+import { patchMibaoImg, handleNftImgError, formatNftDisplayId } from '../../utils/util'
 import { parseSporeCellData } from '../../utils/spore'
 import { useSearchParams } from '../../hooks'
 
@@ -78,7 +78,14 @@ const NftInfo = () => {
       <div className={styles.overview}>
         {renderCover()}
         <div className={styles.info}>
-          <div className={styles.name}>{data ? `${data.collection.name} #${data.token_id}` : '-'}</div>
+          <div className={styles.name}>
+            {data
+              ? `${data.collection.name} ${data.standard === 'spore' ? '' : '#'}${formatNftDisplayId(
+                  data.token_id,
+                  data.standard,
+                )}`
+              : '-'}
+          </div>
           <div className={styles.items}>
             <div className={styles.item}>
               <div>{t('nft.owner')}</div>
@@ -125,7 +132,10 @@ const NftInfo = () => {
             </div>
             <div className={styles.item}>
               <div>Token ID</div>
-              <div>{`#${data?.token_id}`}</div>
+              <div>{`${data?.standard === 'spore' ? '' : '#'}${formatNftDisplayId(
+                data?.token_id ?? '',
+                data?.standard ?? null,
+              )}`}</div>
             </div>
             <div className={styles.item}>
               <div>{t('nft.standard')}</div>

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -355,6 +355,17 @@ export function assertIsHashType(value: string): asserts value is HashType {
   }
 }
 
+export const formatNftDisplayId = (id: string, type: string | null) => {
+  switch (type) {
+    case 'spore': {
+      return `0x${BigNumber(id).toString(16).padStart(64, '0')}`
+    }
+    default: {
+      return id
+    }
+  }
+}
+
 export default {
   copyElementValue,
   shannonToCkb,
@@ -364,4 +375,5 @@ export default {
   deprecatedAddrToNewAddr,
   handleRedirectFromAggron,
   assertIsHashType,
+  formatNftItemId: formatNftDisplayId,
 }


### PR DESCRIPTION
Spore Transfers: https://ckb-explorer-frontend-in-magickbase-repo-7s7na2a17-magickbase.vercel.app/nft-collections/0xb8097e2805224610453262e6da554d518c906c1c7ff06741ba45c91c14a7a3d5
Spore Inventory: https://ckb-explorer-frontend-in-magickbase-repo-7s7na2a17-magickbase.vercel.app/nft-collections/0xb8097e2805224610453262e6da554d518c906c1c7ff06741ba45c91c14a7a3d5?tab=inventory
Spore Item: https://ckb-explorer-frontend-in-magickbase-repo-7s7na2a17-magickbase.vercel.app/nft-info/0xb8097e2805224610453262e6da554d518c906c1c7ff06741ba45c91c14a7a3d5/26664864028786808160865657581855065605803054508180609604351482332803080231409

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/546