### PR TITLE
feat: use isRepatedSymbol to mark omiga inscription's symbol repeated

### DIFF
--- a/src/models/UDT/index.ts
+++ b/src/models/UDT/index.ts
@@ -34,6 +34,7 @@ export interface OmigaInscriptionCollection extends UDT {
   expectedSupply: string
   inscriptionInfoId: string
   infoTypeHash: string
+  isRepeatedSymbol: boolean
 }
 
 export function isOmigaInscriptionCollection(udt: UDT): udt is OmigaInscriptionCollection {

--- a/src/pages/Tokens/index.tsx
+++ b/src/pages/Tokens/index.tsx
@@ -73,7 +73,7 @@ const TokenInfo: FC<{ token: UDT | OmigaInscriptionCollection }> = ({ token }) =
   return (
     <div key={token.typeHash} className={styles.tokenInfo}>
       <span>
-        {isOmigaInscriptionCollection(token) && !token.published && (
+        {isOmigaInscriptionCollection(token) && token.isRepeatedSymbol && (
           <Tooltip placement="topLeft" title={t('udt.repeat_inscription_symbol')} arrowPointAtCenter>
             <WarningOutlined style={{ fontSize: '16px', color: '#FFB21E' }} />
           </Tooltip>
@@ -220,7 +220,7 @@ const TokenTable: FC<{
         return (
           <div className={styles.container}>
             <div className={styles.warningIcon}>
-              {isOmigaInscriptionCollection(token) && !token.published && (
+              {isOmigaInscriptionCollection(token) && token.isRepeatedSymbol && (
                 <Tooltip title={t('udt.repeat_inscription_symbol')}>
                   <WarningOutlined style={{ fontSize: '16px', color: '#FFB21E' }} />
                 </Tooltip>

--- a/src/pages/UDT/state.ts
+++ b/src/pages/UDT/state.ts
@@ -28,4 +28,5 @@ export const defaultOmigaInscriptionInfo: OmigaInscriptionCollection = {
   expectedSupply: '0',
   inscriptionInfoId: '',
   infoTypeHash: '',
+  isRepeatedSymbol: false,
 }


### PR DESCRIPTION
Before we use udt's  published attribute to mark a omiga inscription is repeated symbol or not. But the published value was used in other code and confused us. So we add a new attribute in omiga inscription info table to check omiga inscription was repeated or not.