### PR TITLE
feat: remove native token info from btc address page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "@tanstack/react-query": "4.0.5",
     "antd": "4.24.5",
     "axios": "1.6.7",
+    "bech32": "2.0.0",
     "bignumber.js": "9.1.2",
+    "bs58": "5.0.0",
     "camelcase": "7.0.1",
     "camelcase-keys": "7.0.2",
     "classnames": "2.5.1",
@@ -36,9 +38,7 @@
     "react-router-dom": "5.3.4",
     "react-scripts": "5.0.1",
     "sass": "1.70.0",
-    "styled-components": "5.3.11",
-    "bech32": "2.0.0",
-    "bs58": "5.0.0"
+    "styled-components": "5.3.11"
   },
   "devDependencies": {
     "@sentry/webpack-plugin": "2.10.3",

--- a/src/pages/Address/AddressComp.tsx
+++ b/src/pages/Address/AddressComp.tsx
@@ -14,7 +14,6 @@ import {
   AddressLockScriptController,
   AddressLockScriptPanel,
   AddressTransactionsPanel,
-  AddressUDTAssetsList,
   AddressUDTAssetsPanel,
 } from './styled'
 import Capacity from '../../components/Capacity'
@@ -226,7 +225,7 @@ export const AddressOverviewCard: FC<{ address: Address }> = ({ address }) => {
                 }
                 key={AssetInfo.UDT}
               >
-                <div className="addressUdtAssetsGrid">
+                <div className={styles.assetCardList}>
                   {udts.map(udt => {
                     switch (udt.udtType) {
                       case 'sudt':
@@ -267,7 +266,7 @@ export const AddressOverviewCard: FC<{ address: Address }> = ({ address }) => {
                 }
                 key={AssetInfo.INSCRIPTION}
               >
-                <div className="addressUdtAssetsGrid">
+                <div className={styles.assetCardList}>
                   {inscriptions.map(inscription => {
                     switch (inscription.udtType) {
                       case 'omiga_inscription':
@@ -295,9 +294,9 @@ export const AddressOverviewCard: FC<{ address: Address }> = ({ address }) => {
                 }
                 key={AssetInfo.CELLs}
               >
-                <AddressUDTAssetsList>
+                <div className={styles.assetCardList}>
                   <Cells address={address.addressHash} count={+address.liveCellsCount} />
-                </AddressUDTAssetsList>
+                </div>
               </AddressAssetsTabPane>
             ) : null}
           </AddressAssetsTab>

--- a/src/pages/Address/BTCAddressComp.tsx
+++ b/src/pages/Address/BTCAddressComp.tsx
@@ -1,113 +1,27 @@
 import { useState, FC, useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import { explorerService } from '../../services/ExplorerService'
-import { localeNumberString } from '../../utils/number'
-import { shannonToCkb } from '../../utils/util'
 import {
   AddressAssetsTab,
   AddressAssetsTabPane,
   AddressAssetsTabPaneTitle,
-  AddressLockScriptController,
-  AddressLockScriptPanel,
   AddressUDTAssetsContent,
-  AddressUDTAssetsList,
   AddressUDTAssetsPanel,
 } from './styled'
-import Capacity from '../../components/Capacity'
-import CKBTokenIcon from './ckb_token_icon.png'
 import styles from './styles.module.scss'
-import Script from '../../components/Script'
-import AddressText from '../../components/AddressText'
-import { parseSimpleDateNoSecond } from '../../utils/date'
-import { isMainnet } from '../../utils/chain'
-import ArrowUpIcon from '../../assets/arrow_up.png'
-import ArrowUpBlueIcon from '../../assets/arrow_up_blue.png'
-import ArrowDownIcon from '../../assets/arrow_down.png'
-import ArrowDownBlueIcon from '../../assets/arrow_down_blue.png'
 import { Address, UDTAccount } from '../../models/Address'
-import { Card, CardCellInfo, CardCellsLayout } from '../../components/Card'
+import { Card } from '../../components/Card'
 import Cells from './Cells'
-import {
-  AddressCoTAComp,
-  AddressOmigaInscriptionComp,
-  AddressMNFTComp,
-  AddressSporeComp,
-  AddressSudtComp,
-} from './AddressAssetComp'
+import { AddressOmigaInscriptionComp, AddressMNFTComp, AddressSporeComp, AddressSudtComp } from './AddressAssetComp'
 
 enum AssetInfo {
-  UDT = 1,
-  INSCRIPTION,
   CELLs,
   RGBPP,
-}
-
-const lockScriptIcon = (show: boolean) => {
-  if (show) {
-    return isMainnet() ? ArrowUpIcon : ArrowUpBlueIcon
-  }
-  return isMainnet() ? ArrowDownIcon : ArrowDownBlueIcon
-}
-
-const AddressLockScript: FC<{ address: Address }> = ({ address }) => {
-  const [showLock, setShowLock] = useState<boolean>(false)
-  const { t } = useTranslation()
-
-  const { liveCellsCount, minedBlocksCount, type, addressHash, lockInfo } = address
-  const overviewItems: CardCellInfo<'left' | 'right'>[] = [
-    {
-      title: t('address.live_cells'),
-      tooltip: t('glossary.live_cells'),
-      content: localeNumberString(liveCellsCount),
-    },
-    {
-      title: t('address.block_mined'),
-      tooltip: t('glossary.block_mined'),
-      content: localeNumberString(minedBlocksCount),
-    },
-  ]
-
-  if (type === 'LockHash') {
-    if (!addressHash) {
-      overviewItems.push({
-        title: t('address.address'),
-        content: t('address.unable_decode_address'),
-      })
-    } else {
-      overviewItems.push({
-        title: t('address.address'),
-        contentWrapperClass: styles.addressWidthModify,
-        content: <AddressText>{addressHash}</AddressText>,
-      })
-    }
-  }
-  if (lockInfo && lockInfo.epochNumber !== '0' && lockInfo.estimatedUnlockTime !== '0') {
-    const estimate = Number(lockInfo.estimatedUnlockTime) > new Date().getTime() ? t('address.estimated') : ''
-    overviewItems.push({
-      title: t('address.lock_until'),
-      content: `${lockInfo.epochNumber} ${t('address.epoch')} (${estimate} ${parseSimpleDateNoSecond(
-        lockInfo.estimatedUnlockTime,
-      )})`,
-    })
-  }
-
-  return (
-    <AddressLockScriptPanel className={styles.addressLockScriptPanel}>
-      <CardCellsLayout type="left-right" cells={overviewItems} borderTop />
-      <AddressLockScriptController onClick={() => setShowLock(!showLock)}>
-        <div>{t('address.lock_script')}</div>
-        <img alt="lock script" src={lockScriptIcon(showLock)} />
-      </AddressLockScriptController>
-      {showLock && address.lockScript && <Script script={address.lockScript} />}
-    </AddressLockScriptPanel>
-  )
 }
 
 export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) => {
   const { t, i18n } = useTranslation()
   const { udtAccounts = [] } = address
-  const [activeTab, setActiveTab] = useState<AssetInfo>(AssetInfo.UDT)
+  const [activeTab, setActiveTab] = useState<AssetInfo>(AssetInfo.RGBPP)
 
   const [udts, inscriptions] = udtAccounts.reduce(
     (acc, cur) => {
@@ -130,167 +44,26 @@ export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) =>
     [[] as UDTAccount[], [] as UDTAccount[]],
   )
 
-  const { data: initList } = useQuery(
-    ['cota-list', address.addressHash],
-    () => explorerService.api.fetchNFTItemByOwner(address.addressHash, 'cota'),
-    {
-      enabled: !!address?.addressHash,
-    },
-  )
-
-  const { data: cotaList } = useQuery(['cota-list', initList?.pagination.series], () =>
-    Promise.all(
-      (initList?.pagination.series ?? []).map(p =>
-        explorerService.api.fetchNFTItemByOwner(address.addressHash, 'cota', p),
-      ),
-    ).then(resList => resList.flatMap(res => res.data)),
-  )
-
-  const overviewItems: CardCellInfo<'left' | 'right'>[] = [
-    {
-      slot: 'left',
-      cell: {
-        icon: <img src={CKBTokenIcon} alt="item icon" width="100%" />,
-        title: t('common.ckb_unit'),
-        content: <Capacity capacity={shannonToCkb(address.balance)} />,
-      },
-    },
-    {
-      title: t('address.occupied'),
-      tooltip: t('glossary.occupied'),
-      content: <Capacity capacity={shannonToCkb(address.balanceOccupied)} />,
-    },
-    {
-      title: t('address.dao_deposit'),
-      tooltip: t('glossary.nervos_dao_deposit'),
-      content: <Capacity capacity={shannonToCkb(address.daoDeposit)} />,
-    },
-    {
-      title: t('address.compensation'),
-      content: <Capacity capacity={shannonToCkb(address.daoCompensation)} />,
-      tooltip: t('glossary.nervos_dao_compensation'),
-    },
-  ]
-
-  const hasAssets = udts.length > 0 || (cotaList?.length && cotaList.length > 0)
-  const hasInscriptions = inscriptions.length > 0
+  const hasAssets = udts.length || inscriptions.length
   const hasCells = +address.liveCellsCount > 0
 
   useEffect(() => {
     if (hasAssets) {
       return
     }
-    if (hasInscriptions) {
-      setActiveTab(AssetInfo.INSCRIPTION)
-      return
-    }
     if (hasCells) {
       setActiveTab(AssetInfo.CELLs)
     }
-  }, [hasAssets, hasInscriptions, hasCells, setActiveTab])
+  }, [hasAssets, hasCells, setActiveTab])
 
   return (
     <Card className={styles.addressOverviewCard}>
       <div className={styles.cardTitle}>{t('address.overview')}</div>
 
-      <CardCellsLayout type="leftSingle-right" cells={overviewItems} borderTop />
-
-      {hasAssets || hasInscriptions || hasCells ? (
+      {hasAssets || hasCells ? (
         <AddressUDTAssetsPanel className={styles.addressUDTAssetsPanel}>
           <AddressAssetsTab animated={false} key={i18n.language} activeKey={activeTab.toString()}>
-            {(udts.length > 0 || cotaList?.length) && (
-              <AddressAssetsTabPane
-                tab={
-                  <AddressAssetsTabPaneTitle onClick={() => setActiveTab(AssetInfo.UDT)}>
-                    {t('address.user_defined_token')}
-                  </AddressAssetsTabPaneTitle>
-                }
-                key={AssetInfo.UDT}
-              >
-                <AddressUDTAssetsContent>
-                  <AddressUDTAssetsList>
-                    {udts.map(udt => {
-                      switch (udt.udtType) {
-                        case 'sudt':
-                          return (
-                            <AddressSudtComp
-                              isRGBPP={false}
-                              account={udt}
-                              key={udt.symbol + udt.udtType + udt.amount}
-                            />
-                          )
-
-                        case 'spore_cell':
-                          return (
-                            <AddressSporeComp
-                              isRGBPP={false}
-                              account={udt}
-                              key={udt.symbol + udt.udtType + udt.amount}
-                            />
-                          )
-
-                        case 'm_nft_token':
-                          return (
-                            <AddressMNFTComp
-                              isRGBPP={false}
-                              account={udt}
-                              key={udt.symbol + udt.udtType + udt.amount}
-                            />
-                          )
-                        default:
-                          return null
-                      }
-                    })}
-                    {cotaList?.map(cota => (
-                      <AddressCoTAComp
-                        isRGBPP={false}
-                        account={{
-                          udtType: 'cota',
-                          symbol: cota.collection.name,
-                          udtIconFile: cota.collection.icon_url ?? '',
-                          cota: {
-                            cotaId: cota.collection.id,
-                            tokenId: Number(cota.token_id),
-                          },
-                        }}
-                        key={cota.collection.id + cota.token_id}
-                      />
-                    )) ?? null}
-                  </AddressUDTAssetsList>
-                </AddressUDTAssetsContent>
-              </AddressAssetsTabPane>
-            )}
-            {hasInscriptions ? (
-              <AddressAssetsTabPane
-                tab={
-                  <AddressAssetsTabPaneTitle onClick={() => setActiveTab(AssetInfo.INSCRIPTION)}>
-                    {t('address.inscription')}
-                  </AddressAssetsTabPaneTitle>
-                }
-                key={AssetInfo.INSCRIPTION}
-              >
-                <AddressUDTAssetsContent>
-                  <AddressUDTAssetsList>
-                    {inscriptions.map(inscription => {
-                      switch (inscription.udtType) {
-                        case 'omiga_inscription':
-                          return (
-                            <AddressOmigaInscriptionComp
-                              isRGBPP={false}
-                              account={inscription}
-                              key={`${inscription.symbol + inscription.udtType + inscription.udtAmount}`}
-                            />
-                          )
-
-                        default:
-                          return null
-                      }
-                    })}
-                  </AddressUDTAssetsList>
-                </AddressUDTAssetsContent>
-              </AddressAssetsTabPane>
-            ) : null}
-            {(hasInscriptions || hasAssets) && (
+            {hasAssets ? (
               <AddressAssetsTabPane
                 tab={
                   <AddressAssetsTabPaneTitle onClick={() => setActiveTab(AssetInfo.RGBPP)}>
@@ -300,7 +73,7 @@ export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) =>
                 key={AssetInfo.RGBPP}
               >
                 <AddressUDTAssetsContent>
-                  <AddressUDTAssetsList>
+                  <div className={styles.assetCardList}>
                     {udts.map(udt => {
                       switch (udt.udtType) {
                         case 'sudt':
@@ -315,21 +88,7 @@ export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) =>
                           return null
                       }
                     })}
-                    {cotaList?.map(cota => (
-                      <AddressCoTAComp
-                        isRGBPP
-                        account={{
-                          udtType: 'cota',
-                          symbol: cota.collection.name,
-                          udtIconFile: cota.collection.icon_url ?? '',
-                          cota: {
-                            cotaId: cota.collection.id,
-                            tokenId: Number(cota.token_id),
-                          },
-                        }}
-                        key={cota.collection.id + cota.token_id}
-                      />
-                    )) ?? null}
+
                     {inscriptions.map(inscription => {
                       switch (inscription.udtType) {
                         case 'omiga_inscription':
@@ -345,10 +104,10 @@ export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) =>
                           return null
                       }
                     })}
-                  </AddressUDTAssetsList>
+                  </div>
                 </AddressUDTAssetsContent>
               </AddressAssetsTabPane>
-            )}
+            ) : null}
 
             {hasCells ? (
               <AddressAssetsTabPane
@@ -359,16 +118,14 @@ export const BTCAddressOverviewCard: FC<{ address: Address }> = ({ address }) =>
                 }
                 key={AssetInfo.CELLs}
               >
-                <AddressUDTAssetsList>
+                <div className={styles.assetCardList}>
                   <Cells address={address.addressHash} count={+address.liveCellsCount} />
-                </AddressUDTAssetsList>
+                </div>
               </AddressAssetsTabPane>
             ) : null}
           </AddressAssetsTab>
         </AddressUDTAssetsPanel>
       ) : null}
-
-      <AddressLockScript address={address} />
     </Card>
   )
 }

--- a/src/pages/Address/styled.tsx
+++ b/src/pages/Address/styled.tsx
@@ -154,23 +154,6 @@ export const AddressAssetsTabPaneTitle = styled.span`
   text-align: left;
 `
 
-export const AddressUDTAssetsList = styled.div`
-  overflow-y: scroll;
-  width: 100%;
-  display: flex;
-  gap: 16px;
-  background-color: #f1f1f1;
-  flex-flow: row wrap;
-
-  @media (min-width: ${variables.extraLargeBreakPoint}) {
-    max-height: 153px;
-  }
-
-  @media (max-width: ${variables.extraLargeBreakPoint}) {
-    max-height: 252px;
-  }
-`
-
 export const AddressUDTAssetsContent = styled.div`
   background-color: #f1f1f1;
   padding: 16px 25px;

--- a/src/pages/Address/styles.module.scss
+++ b/src/pages/Address/styles.module.scss
@@ -290,3 +290,22 @@
   height: 3rem;
   font-size: 1rem;
 }
+
+.assetCardList {
+  margin-top: 10px;
+  background-color: #f1f1f1;
+  padding: 6px 25px;
+  width: 100%;
+  display: flex;
+  flex-flow: row wrap;
+  overflow-y: scroll;
+  gap: 1rem;
+
+  @media (width >= $extraLargeBreakPoint) {
+    max-height: 220px;
+  }
+
+  @media (width <= $extraLargeBreakPoint) {
+    max-height: 310px;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7292,7 +7292,7 @@ batch@0.6.1:
 
 bech32@2.0.0, bech32@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
   integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 better-opn@^3.0.2:
@@ -7520,7 +7520,7 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
-bs58@5.0.0:
+bs58@5.0.0, bs58@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
   integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==


### PR DESCRIPTION
1. remove ckb info from btc address page
2. fix style of asset list

Before
<img width="817" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/b6cad9c4-0055-4123-8b43-d1bc77c2a722">
<img width="509" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/278caacc-9024-4049-9f7e-d1e6ce7389e7">
<img width="2792" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/89d96857-a119-4947-ab35-984d984e9b59">

After:
<img width="2804" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/994bf0e8-30c4-4e73-9d2e-b4c9a7daa358">
<img width="1978" alt="image" src="https://github.com/Magickbase/ckb-explorer-frontend/assets/7271329/ccca86d3-71d3-4401-a98e-d09d11b02491">
