### PR TITLE
style: adjust tooltip style

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -90,6 +90,8 @@ a {
 
 .ant-tooltip-inner {
   white-space: pre-wrap;
+  border-radius: 8px;
+  padding: 10px 16px;
 }
 
 a:hover,


### PR DESCRIPTION
resolve: https://github.com/Magickbase/ckb-explorer-public-issues/issues/537

I checked that the current `tooltip` components are all import from `antd`
and then I see that to be different between `antd` and the `design ui` are the `padding` and `border-radius`.

So I've only changed the style, if there's something else need to change can leave a comment