### PR TITLE
fix(link): link should not use pathname property when using relative

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -28,7 +28,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps<unknown>>((({ lng, t
     return (location: H.Location) => addI18nPrefix(to(location), lng ?? locale)
   }, [lng, locale, to])
 
-  return <RouterLink ref={ref} {...props} to={{ pathname: toWithPrefix }} />
+  return <RouterLink ref={ref} {...props} to={toWithPrefix} />
   // The `as` here is to allow the generic type to be correctly inferred.
 }) as <S>(props: LinkProps<S>, ref: ForwardedRef<HTMLAnchorElement>) => JSX.Element)
 


### PR DESCRIPTION
Fix the `Link` component, when using the relative uri, `pathname` property should be used.