### PR TITLE
fix: updating the `slatetime` to fix the `initialData` causes an prevent fetch data error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,8 @@ const appStyle = {
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: Infinity,
+      staleTime: 60 * 1000,
+      initialDataUpdatedAt: 0,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       refetchIntervalInBackground: false,

--- a/src/pages/Transaction/TransactionComp/RGBDigestComp.tsx
+++ b/src/pages/Transaction/TransactionComp/RGBDigestComp.tsx
@@ -22,38 +22,26 @@ export const RGBDigestComp = ({ hash, txid }: { hash: string; txid?: string }) =
     explorerService.api.fetchRGBDigest(hash),
   )
 
-  const { data: displayInputs } = useQuery(
-    ['transaction_inputs', hash, 1, 10],
-    async () => {
-      try {
-        const res = await explorerService.api.fetchCellsByTxHash(hash, 'inputs', { no: 1, size: 10 })
-        return res
-      } catch (e) {
-        return { data: [] }
-      }
-    },
-    {
-      initialData: { data: [] },
-    },
-  )
+  const { data: displayInputs = { data: [] } } = useQuery(['transaction_inputs', hash, 1, 10], async () => {
+    try {
+      const res = await explorerService.api.fetchCellsByTxHash(hash, 'inputs', { no: 1, size: 10 })
+      return res
+    } catch (e) {
+      return { data: [] }
+    }
+  })
 
-  const { data: displayOutputs } = useQuery(
-    ['transaction_outputs', hash, 1, 10],
-    async () => {
-      try {
-        const res = await explorerService.api.fetchCellsByTxHash(hash, 'outputs', {
-          no: 1,
-          size: 10,
-        })
-        return res
-      } catch (e) {
-        return { data: [] }
-      }
-    },
-    {
-      initialData: { data: [] },
-    },
-  )
+  const { data: displayOutputs = { data: [] } } = useQuery(['transaction_outputs', hash, 1, 10], async () => {
+    try {
+      const res = await explorerService.api.fetchCellsByTxHash(hash, 'outputs', {
+        no: 1,
+        size: 10,
+      })
+      return res
+    } catch (e) {
+      return { data: [] }
+    }
+  })
   const boundCellIndex = useMemo(() => {
     const map: Record<string, number> = {}
     displayInputs.data.forEach((input, idx) => {


### PR DESCRIPTION
Currently this page can't get input and output data： https://pudge.explorer.nervos.org/transaction/0x69f3fa734a755aafb4337217b37f27adfc4656be594080bde35fb258e6a28019

This error is due to the `slatetime` of the `queryclient` is set to `infinite`, and when `initialdata` is existed, the `useQuery` will prevent fetch new data