### PR TITLE
fix: tags display exception for tx cells

### DIFF
--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -88,8 +88,8 @@ const TransactionCellIndexAddress = ({
   const deprecatedAddr = useDeprecatedAddr(cell.addressHash)!
   const newAddr = useNewAddr(cell.addressHash)
   const address = isAddrNew ? newAddr : deprecatedAddr
-  const isFiber = cell.tags?.findIndex(tag => tag === 'fiber') !== -1
-  const isDeployment = cell.tags?.findIndex(tag => tag === 'deployment') !== -1
+  const isFiber = (cell.tags ?? []).find(tag => tag === 'fiber') !== undefined
+  const isDeployment = (cell.tags ?? []).find(tag => tag === 'deployment') !== undefined
 
   let since
   try {


### PR DESCRIPTION
Fixed a bug where cells that were not fiber were marked as fiber.

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/e1b4bd47-0f58-4f20-b52b-466e02367fe7" />
