### PR TITLE
fix: prevent navigation for 'other' title in miner address chart

### DIFF
--- a/src/pages/StatisticsChart/mining/MinerAddressDistribution.tsx
+++ b/src/pages/StatisticsChart/mining/MinerAddressDistribution.tsx
@@ -97,6 +97,9 @@ export const MinerAddressDistributionChart = ({ isThumbnail = false }: { isThumb
   const history = useHistory()
   const onClick = useCallback(
     (param: echarts.CallbackDataParams) => {
+      if (param && param.data.title === 'other') {
+        return
+      }
       if (param && param.data.title) {
         history.push(`/${language}/address/${param.data.title}`)
       }


### PR DESCRIPTION
https://github.com/Magickbase/ckb-explorer-public-issues/issues/818