### PR TITLE
chore: unify the display of multisig script version everywhere

### DIFF
--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -4,8 +4,8 @@ import { predefined } from '@ckb-lumos/config-manager'
 import { Script } from '../models/Script'
 
 export const SCRIPT_TAGS = {
-  SECP_MULTISIG: 'secp256k1 / multisig',
-  SECP_MULTISIG_LOCKTIME: 'secp256k1 / multisig / locktime',
+  SECP_MULTISIG: 'SECP256K1 / Multisig',
+  SECP_MULTISIG_LOCKTIME: 'SECP256K1 / Multisig / locktime',
 } as const
 
 export interface ContractHashTag {

--- a/src/pages/Address/AddressPage.tsx
+++ b/src/pages/Address/AddressPage.tsx
@@ -259,7 +259,7 @@ export const Address = () => {
                 <Tooltip trigger={<img src={MultisigIcon} alt="multisig" />} placement="top">
                   <div>
                     <div>
-                      Multisig <span className="text-primary">(@{addressInfo?.lockScript.codeHash.slice(0, 6)})</span>
+                      Multisig <span className="text-primary">(@{addressInfo?.lockScript.codeHash.slice(2, 10)})</span>
                     </div>
                     <div>
                       <div className={styles.copyCodeHash}>

--- a/src/pages/ScriptList/index.tsx
+++ b/src/pages/ScriptList/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { TFunction } from 'i18next'
 import classNames from 'classnames'
+import { SCRIPT_TAGS } from '../../constants/scripts'
 import Content from '../../components/Content'
 import styles from './styles.module.scss'
 import { explorerService } from '../../services/ExplorerService'
@@ -36,7 +37,7 @@ export const scripts = new Map<string, ScriptAttributes>([
     },
   ],
   [
-    'secp256k1 / multisig',
+    SCRIPT_TAGS.SECP_MULTISIG,
     {
       name: 'SECP256K1/multisig',
       description: 'SECP256K1/multisig is a script which allows a group of users to sign a single transaction.',

--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -416,7 +416,7 @@ export const TransactionCellDetail = ({ cell }: { cell: Cell }) => {
       key: 'Multisig',
       tag: (
         <>
-          Multisig <span className="text-primary">@{lockScript.codeHash.slice(0, 6)}</span>
+          Multisig <span className="text-primary">(@{lockScript.codeHash.slice(2, 10)})</span>
         </>
       ),
       description: 'This cell is related to Multisig. It can be used to create a multisig address.',


### PR DESCRIPTION

before:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/40a54014-805a-4d18-ba15-2a97d41e8f70" />
<img width="311" alt="image" src="https://github.com/user-attachments/assets/2cd08184-140a-4630-8b70-d67acccd4935" />
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/25f1d4dc-0013-4cb7-985a-a57aa76d11f5" />


after:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/0a019129-b518-4b4f-bd26-e4bac241dd3f" />
<img width="311" alt="image" src="https://github.com/user-attachments/assets/b1ebcfb3-c307-44a8-86b2-03a3e503000a" />
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/f5bd827a-7b81-45fd-baf2-05959e0b51aa" />

